### PR TITLE
Fix QPainter warnings when using multiple instances of widget under s…

### DIFF
--- a/SlidingStackedWidget/slidingstackedwidget.cpp
+++ b/SlidingStackedWidget/slidingstackedwidget.cpp
@@ -160,6 +160,10 @@ void SlidingStackedWidget::slideInWgt(QWidget * newwidget, enum t_direction dire
        animnow_op->setDuration(m_speed/2);
        animnow_op->setStartValue(1);
        animnow_op->setEndValue(0);
+       connect(animnow_op,&QPropertyAnimation::finished,[=](){
+           if(animnow_op_eff  != nullptr)
+              animnow_op_eff->deleteLater();
+       });
 
        QGraphicsOpacityEffect *animnext_op_eff = new QGraphicsOpacityEffect();
        animnext_op_eff->setOpacity(0);
@@ -168,6 +172,10 @@ void SlidingStackedWidget::slideInWgt(QWidget * newwidget, enum t_direction dire
        animnext_op->setDuration(m_speed/2);
        animnext_op->setStartValue(0);
        animnext_op->setEndValue(1);
+       connect(animnext_op,&QPropertyAnimation::finished,[=](){
+           if(animnext_op_eff != nullptr)
+              animnext_op_eff->deleteLater();
+       });
 
        QPropertyAnimation *animnext = new QPropertyAnimation(widget(next), "pos");
        animnext->setDuration(m_speed);
@@ -185,12 +193,12 @@ void SlidingStackedWidget::slideInWgt(QWidget * newwidget, enum t_direction dire
        m_next=next;
        m_now=now;
        m_active=true;
-       animgroup->start();
+       animgroup->start(QAbstractAnimation::DeleteWhenStopped);
 }
 
 
-void SlidingStackedWidget::animationDoneSlot() {
-
+void SlidingStackedWidget::animationDoneSlot()
+{
    setCurrentIndex(m_next);
    widget(m_now)->hide();
    widget(m_now)->move(m_pnow);

--- a/SlidingStackedWidget/slidingstackedwidget.h
+++ b/SlidingStackedWidget/slidingstackedwidget.h
@@ -54,7 +54,8 @@ public slots:
        bool slideInPrev();
        //! Slide to page x
        void slideInIdx(int idx, enum t_direction direction=AUTOMATIC);
-
+        //! Slide to page with widget
+       void slideInWgt(QWidget * widget, enum t_direction direction=AUTOMATIC);
 signals:
        //! Animation is finished
        void animationFinished(void);
@@ -63,7 +64,6 @@ protected slots:
        void animationDoneSlot(void);
 
 protected:
-       void slideInWgt(QWidget * widget, enum t_direction direction=AUTOMATIC);
        QWidget *m_mainwindow;
        int m_speed;
        enum QEasingCurve::Type m_animationtype;


### PR DESCRIPTION
I have made some improvements to your Widget class: most notable one are-

* Ability to use multiple instances of widget under a same parent widget, earlier this was causing QPainter warnings like Only one Painter can Paint a widget at a time.
* Made the slideInWgt(QWidget *widget) function public, so it could directly be used to switch desired widget. //If user pass widget that is not in scope of QStackWidget Qt will throw warning and that's OK. This behaviour is replication of QStackWidget's setcurrentWidget(QWidget *widget) which is able to handle out of scope widgets.
* Proper deletion of QPropertyAnimation objects created at runtime after they are finished.